### PR TITLE
Fix in trace_generator.py

### DIFF
--- a/sweeps/generators/trace_generator.py
+++ b/sweeps/generators/trace_generator.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import tempfile
+import shutil
 
 from xenon.base.datatypes import *
 from xenon.generators import base_generator
@@ -74,7 +75,7 @@ class TraceGenerator(base_generator.Generator):
           os.makedirs(trace_abs_dir)
         # Moves and overwrites a trace at the destination if it already exists.
         trace_new_path = os.path.join(trace_abs_dir, DYNAMIC_TRACE)
-        os.rename(trace_orig_path, trace_new_path)
+        shutil.move(trace_orig_path, trace_new_path)
         genfiles.append(trace_new_path)
 
         # Cleanup.


### PR DESCRIPTION
I am using the gem5-aladdin Docker image. I attempted to generate the simulation files in a directory different from `/workspace/gem5-aladdin/sweeps`, and while `configs` and `gem5_binary` generated without issue, `trace` was throwing an error:

```
use benchmarks.designsweeptypes.Gem5DesignSweep
begin Gem5DesignSweep boa_experiment
use benchmarks.machsuite.*
generate configs
generate trace
generate gem5_binary
set output_dir "output_dir"
set source_dir "/workspace/gem5-aladdin/src/aladdin/MachSuite"
set simulator "gem5-cpu"
set memory_type "cache"
set cycle_time 5
set unrolling for bfs_bulk.bfs.loop_horizons 1
set unrolling for bfs_bulk.bfs.loop_neighbors 0
set unrolling for bfs_bulk.bfs.init_horizons 0
set unrolling for bfs_queue.bfs.init_horizons 0
set unrolling for gemm_blocked.bbgemm.loopjj 1
set unrolling for gemm_blocked.bbgemm.loopkk 1
set unrolling for gemm_blocked.bbgemm.loopk 0
set unrolling for gemm_blocked.bbgemm.loopj 0
set unrolling for gemm_ncubed.gemm.outer 1
set unrolling for gemm_ncubed.gemm.inner 0
set unrolling for kmp_kmp.CPF.c2 1
set unrolling for kmp_kmp.kmp.k2 1
set unrolling for md_grid.md.loop_grid0_x 1
set unrolling for md_grid.md.loop_grid0_y 1
set unrolling for md_grid.md.loop_grid0_z 1
set unrolling for md_grid.md.loop_grid1_x 1
set unrolling for md_grid.md.loop_grid1_y 1
set unrolling for md_grid.md.loop_grid1_z 1
set unrolling for md_grid.md.loop_p 0
set unrolling for md_grid.md.loop_q 0
set unrolling for sort_radix.last_step_scan.last_2 0
set unrolling for sort_radix.local_scan.local_2 0
set unrolling for sort_radix.hist.hist_2 0
set unrolling for sort_radix.update.update_2 0
set unrolling for sort_radix.ss_sort.sort_1 1
set unrolling for spmv_crs.spmv.spmv_2 0
set unrolling for spmv_ellpack.ellpack.ellpack_2 0
set unrolling for md_knn.md_kernel.loop_j 0
set unrolling for nw_nw.needwun.fill_in 0
set unrolling for nw_nw.needwun.trace 1
set unrolling for nw_nw.needwun.pad_a 1
set unrolling for nw_nw.needwun.pad_b 1
set unrolling for sort_merge.ms_mergesort.mergesort_label1 1
set unrolling for sort_merge.ms_mergesort.mergesort_label2 1
set unrolling for stencil_stencil2d.stencil.stencil_label1 1
set unrolling for stencil_stencil2d.stencil.stencil_label3 0
set unrolling for stencil_stencil2d.stencil.stencil_label4 0
set unrolling for stencil_stencil3d.stencil3d.height_bound_col 1
set unrolling for stencil_stencil3d.stencil3d.height_bound_row 0
set unrolling for stencil_stencil3d.stencil3d.col_bound_height 1
set unrolling for stencil_stencil3d.stencil3d.col_bound_row 0
set unrolling for stencil_stencil3d.stencil3d.row_bound_height 1
set unrolling for stencil_stencil3d.stencil3d.row_bound_col 0
set unrolling for stencil_stencil3d.stencil3d.loop_height 1
set unrolling for stencil_stencil3d.stencil3d.loop_row 0
set memory_type for aes_aes.rcon "spad"
set memory_type for fft_transpose.twiddles8.reversed8 "spad"
set memory_type for fft_transpose.data_x "spad"
set memory_type for fft_transpose.data_y "spad"
set memory_type for kmp_kmp.pattern "spad"
set memory_type for kmp_kmp.kmpNext "spad"
set memory_type for kmp_kmp.n_matches "spad"
set memory_type for stencil_stencil2d.filter "spad"
set memory_type for stencil_stencil3d.C "spad"
set memory_type for viterbi_viterbi.obs "spad"
set partition_type for aes_aes.rcon "complete"
set partition_type for fft_transpose.twiddles8.reversed8 "complete"
set partition_type for fft_transpose.data_x "complete"
set partition_type for fft_transpose.data_y "complete"
set partition_type for kmp_kmp.pattern "complete"
set partition_type for kmp_kmp.kmpNext "complete"
set partition_type for stencil_stencil2d.filter "complete"
set partition_type for stencil_stencil3d.C "complete"
set partition_type for viterbi_viterbi.obs "complete"
set memory_type for aes_aes.sbox "spad"
set memory_type for bfs_queue.queue "spad"
set memory_type for fft_transpose.work_x "spad"
set memory_type for fft_transpose.work_y "spad"
set memory_type for fft_transpose.DATA_x "spad"
set memory_type for fft_transpose.DATA_y "spad"
set memory_type for fft_transpose.smem "spad"
set memory_type for nw_nw.M "spad"
set memory_type for nw_nw.ptr "spad"
set memory_type for sort_merge.temp "spad"
set memory_type for sort_radix.b "spad"
set memory_type for sort_radix.bucket "spad"
set memory_type for sort_radix.sum "spad"
set memory_type for viterbi_viterbi.llike "spad"
end boa_experiment
Building gem5 binaries for aes_aes
Building gem5 binaries for bfs_bulk
Building gem5 binaries for bfs_queue
Building gem5 binaries for fft_strided
Building gem5 binaries for fft_transpose
Building gem5 binaries for gemm_blocked
Building gem5 binaries for gemm_ncubed
Building gem5 binaries for kmp_kmp
Building gem5 binaries for md_grid
Building gem5 binaries for md_knn
Building gem5 binaries for nw_nw
Building gem5 binaries for sort_merge
Building gem5 binaries for sort_radix
Building gem5 binaries for spmv_crs
Building gem5 binaries for spmv_ellpack
Building gem5 binaries for stencil_stencil2d
Building gem5 binaries for stencil_stencil3d
Building gem5 binaries for viterbi_viterbi
Building non-DMA traces for aes_aes
Traceback (most recent call last):
  File "/workspace/gem5-aladdin/sweeps/generate_design_sweeps.py", line 31, in <module>
    main()
  File "/workspace/gem5-aladdin/sweeps/generate_design_sweeps.py", line 28, in main
    run(args.xenon_file)
  File "/workspace/gem5-aladdin/sweeps/generate_design_sweeps.py", line 12, in run
    genfiles = interpreter.run()
  File "/workspace/gem5-aladdin/sweeps/xenon/xenon_interpreter.py", line 87, in run
    genfiles = self.generate_outputs()
  File "/workspace/gem5-aladdin/sweeps/xenon/xenon_interpreter.py", line 80, in generate_outputs
    generated_files = sweep.generateAllOutputs()
  File "/workspace/gem5-aladdin/sweeps/xenon/base/datatypes.py", line 408, in generateAllOutputs
    genfiles = generator()
  File "/workspace/gem5-aladdin/sweeps/benchmarks/designsweeptypes.py", line 44, in generate_trace
    return generator.run()
  File "/workspace/gem5-aladdin/sweeps/generators/trace_generator.py", line 77, in run
    os.rename(trace_orig_path, trace_new_path)
OSError: [Errno 18] Invalid cross-device link: '/workspace/gem5-aladdin/src/aladdin/MachSuite/aes/aes/dynamic_trace.gz' -> '/workspace/boa/test/warmup/output_dir/aes_aes/inputs/dynamic_trace.gz'
```

I managed to fix this by slightly modifying `gem5-aladdin/sweeps/generators/trace_generator.py`. In particular, after inserting `import shutil` at the top, I modified line 77 from `os.rename(…)` to `shutil.move(…)`, which according to https://stackoverflow.com/questions/42392600/oserror-errno-18-invalid-cross-device-link seems to be the recommended way of moving files in Python 3, though it might still error out in Python 2.