### PR TITLE
tests: Add CircleCI configuration.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,74 @@
+version: 2.1
+orbs:
+  docker: circleci/docker@1.3.0
+jobs:
+  build:
+    docker:
+      - image: xyzsam/gem5-aladdin:latest
+    environment:
+      ALADDIN_HOME: /root/project/src/aladdin
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-gem5-build-cache
+      - run:
+          name: Checkout dependencies
+          command: git submodule update --init --recursive
+      - run:
+          name: Compile
+          command: |
+            mkdir -p build/variables
+            cat \<< EOF > build/variables/X86
+            TARGET_ISA = 'x86'
+            CPU_MODELS = 'AtomicSimpleCPU,O3CPU,TimingSimpleCPU'
+            PROTOCOL = 'MESI_Two_Level_aladdin'
+            EOF
+            python2.7 `which scons` build/X86/gem5.opt PROTOCOL=MESI_Two_Level_aladdin --ignore-style -j2
+      - run:
+          name: Running integration tests
+          command: |
+            python3 src/aladdin/integration-test/common/run_cpu_tests.py
+            python3 src/aladdin/integration-test/common/run_ruby_tests.py
+      - save_cache:
+          key: v1-gem5-build-cache
+          paths:
+            # This DB stores all the file signatures, which SCons uses to determine
+            # what has changed.
+            - build/sconsign
+            # This stores the conftest files used to check for dependencies.
+            # Unfortunately, these C files also get recorded in the sconsign DB, so
+            # if the DB thinks they're present but we don't cache them, checking for
+            # dependencies will fail.
+            - build/.scons_config
+            # Cache everything we're not likely to modify. So exclude aladdin and all
+            # top level files in mem, sim, and dev.
+            - build/X86/arch
+            - build/X86/cpu
+            - build/X86/proto
+            - build/X86/python
+            - build/X86/enums
+            - build/X86/base
+            - build/X86/gpu-compute
+            - build/X86/unittest
+            - build/X86/debug
+            - build/X86/params
+            - build/X86/kern
+            - build/X86/mem/protocol
+            - build/X86/mem/cache
+            - build/X86/mem/ruby
+            - build/X86/mem/probes
+            - build/X86/sim/power
+            - build/X86/sim/probe
+            - build/X86/dev/alpha
+            - build/X86/dev/arm
+            - build/X86/dev/i2c
+            - build/X86/dev/mips
+            - build/X86/dev/net
+            - build/X86/dev/pci
+            - build/X86/dev/sparc
+            - build/X86/dev/storage
+            - build/X86/dev/virtio
+            - build/X86/dev/x86
+      - store_artifacts:
+          path: build/X86/gem5.opt

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "aladdin"]
   path = src/aladdin
-  url = https://github.com/ysshao/aladdin
+  url = https://github.com/harvard-acc/aladdin
 [submodule "xenon"]
 	path = sweeps/xenon
 	url = https://github.com/xyzsam/xenon


### PR DESCRIPTION
This switches our continuous integration provider from Travis to
CircleCI. On CircleCI, we can do a clean build of gem5 in just 35
minutes, compared to 1.5 hours on Travis. This means we can get rid of
that terrible build cache hack for Travis.