### PR TITLE
Fix busy waiting on finish_flag

### DIFF
--- a/src/mem/cache/mshr.cc
+++ b/src/mem/cache/mshr.cc
@@ -422,6 +422,7 @@ MSHR::handleSnoop(PacketPtr pkt, Counter _order)
     // should always be the same, however, this assumes that we never
     // snoop writes as they are currently not marked as invalidations
     panic_if((pkt->needsWritable() != pkt->isInvalidate()) &&
+             !pkt->req->isUncacheable() &&
              !pkt->req->isCacheMaintenance(),
              "%s got snoop %s where needsWritable, "
              "does not match isInvalidate", name(), pkt->print());


### PR DESCRIPTION
If the program that invokes the accelerator loops on the `finish_flag` instead of waiting for an interrupt, it will likely panic and die. This is caused by the accelerator writing to an uncacheable memory region and the CPU MSHR being unaware of it. Because the `finish_flag` is uncacheable, the accelerator's write request sets the `needsWriteable` flag of the memory packet but not the `isInvalidate` flag. The CPU MSHR, which is not aware of the presence of uncacheable memory, assumes both must be set or neither, triggering the panic.