### PR TITLE
systolic-array: Fix access size in scratchpad.

### DIFF
--- a/src/systolic_array/scratchpad.cpp
+++ b/src/systolic_array/scratchpad.cpp
@@ -19,12 +19,13 @@ Scratchpad::Scratchpad(const Params* p)
 void Scratchpad::accessData(Addr addr, int size, uint8_t* data, bool isRead) {
   uint8_t* ptr = nullptr;
   Addr currAddr = addr;
+  int accessSize = std::min(size, lineSize);
   for (int i = 0; i < size; i += lineSize) {
     ptr = &data[i];
     if (isRead)
-      chunk.readData(currAddr, ptr, lineSize);
+      chunk.readData(currAddr, ptr, accessSize);
     else
-      chunk.writeData(currAddr, ptr, lineSize);
+      chunk.writeData(currAddr, ptr, accessSize);
     currAddr += lineSize;
   }
 }


### PR DESCRIPTION
The size of a write request sent from a commit unit can be smaller than the
line size in the scratchpad for a small PE array configuration. This bug can
lead to wrong outputs and also memory corruptions that eventually cause
simulation failure.